### PR TITLE
ux: answer follow-up comments by default

### DIFF
--- a/.github/workflows/scribe-awakening.yml
+++ b/.github/workflows/scribe-awakening.yml
@@ -25,21 +25,21 @@ jobs:
   scribe-reflection:
     # Agent1 reply rules:
     # - issues.opened: always reply
-    # - issue_comment.created: reply on explicit summon OR a natural follow-up question
-    #   - summon: awaken/@agent1/@MirrorAgent1
-    #   - natural question: contains "?" (kept simple for GitHub expression compatibility)
+    # - issue_comment.created: reply to normal human comments (natural follow-ups)
+    #   while ignoring obvious low-signal acknowledgements.
     # - ignore bot/self/Agent0 to prevent loops
     if: |
       github.event_name != 'issue_comment' || (
         github.event.comment.user.login != 'github-actions[bot]' &&
         github.event.comment.user.login != 'MirrorAgent1' &&
         github.event.comment.user.login != 'toadaid-agent0' &&
-        (
-          contains(github.event.comment.body, 'awaken') ||
-          contains(github.event.comment.body, '@agent1') ||
-          contains(github.event.comment.body, '@MirrorAgent1') ||
-          contains(github.event.comment.body, '?')
-        )
+        github.event.comment.body != null &&
+        github.event.comment.body != '' &&
+        !contains(toLower(github.event.comment.body), 'thanks') &&
+        !contains(toLower(github.event.comment.body), 'thank you') &&
+        !contains(toLower(github.event.comment.body), 'gm') &&
+        !contains(toLower(github.event.comment.body), 'good morning') &&
+        !contains(toLower(github.event.comment.body), 'ok')
       )
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This repo uses GitHub Issues as the "pond" interface.
 3) The Cave Scribe will reply as a comment (powered by GitHub Actions)
 
 Tip: you can also ask follow-ups by commenting on the same issue.
-- If you ask a natural question (include a `?`), the Scribe will respond.
-- You can always force a reply by commenting `awaken`.
+- Normal follow-up comments will be answered (anti-spam cooldown applies).
+- If you just want to say thanks, it may not respond (by design).
 
 ## 🌊 Join the Pond
 

--- a/docs/FORK_GUIDE.md
+++ b/docs/FORK_GUIDE.md
@@ -106,6 +106,10 @@ Open an Issue using the template:
 The reply should include:
 - Signal / Reflection / Sources
 
+Follow-ups:
+- Just comment your next question in the same Issue.
+- If you only comment "thanks" / "gm" / "ok", the agent may not reply (by design).
+
 If it doesn’t cite sources, the script retries once automatically.
 
 ## 7) Keep your fork updated (receive new features/fixes)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -165,8 +165,8 @@ This generates/updates:
 Open an Issue in the repo with your question in the title/body.
 The Cave Scribe will reply as a comment.
 
-Tip: commenting `awaken` on an existing issue triggers a new response.
-Tip: natural follow-ups work too — ask a real question (include a `?`).
+Tip: follow-ups work naturally — just comment your next question in the same Issue.
+(There is still an anti-spam cooldown to prevent loops.)
 
 ## 9) Keeping your fork up to date (so you receive new features)
 


### PR DESCRIPTION
Toadgang UX: follow-up questions in the same Issue should be answered naturally.

Change:
- issue_comment triggers scribe-reflection for normal human comments (no need to type awaken or mention Agent1)
- skips obvious low-signal acknowledgements (thanks/gm/ok) to reduce noise
- loop guards + cooldown remain
- docs updated to match