### PR TITLE
fix: restore workflow validity on forks (remove toLower())

### DIFF
--- a/.github/workflows/scribe-awakening.yml
+++ b/.github/workflows/scribe-awakening.yml
@@ -35,11 +35,21 @@ jobs:
         github.event.comment.user.login != 'toadaid-agent0' &&
         github.event.comment.body != null &&
         github.event.comment.body != '' &&
-        !contains(toLower(github.event.comment.body), 'thanks') &&
-        !contains(toLower(github.event.comment.body), 'thank you') &&
-        !contains(toLower(github.event.comment.body), 'gm') &&
-        !contains(toLower(github.event.comment.body), 'good morning') &&
-        !contains(toLower(github.event.comment.body), 'ok')
+        !contains(github.event.comment.body, 'thanks') &&
+        !contains(github.event.comment.body, 'Thanks') &&
+        !contains(github.event.comment.body, 'THANKS') &&
+        !contains(github.event.comment.body, 'thank you') &&
+        !contains(github.event.comment.body, 'Thank you') &&
+        !contains(github.event.comment.body, 'THANK YOU') &&
+        !contains(github.event.comment.body, 'gm') &&
+        !contains(github.event.comment.body, 'GM') &&
+        !contains(github.event.comment.body, 'Gm') &&
+        !contains(github.event.comment.body, 'good morning') &&
+        !contains(github.event.comment.body, 'Good morning') &&
+        !contains(github.event.comment.body, 'GOOD MORNING') &&
+        !contains(github.event.comment.body, 'ok') &&
+        !contains(github.event.comment.body, 'Ok') &&
+        !contains(github.event.comment.body, 'OK')
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
GitHub Actions expressions don't support toLower(), which can invalidate the workflow file on forks (shows as .github/workflows/scribe-awakening.yml and push runs fail).

This patch removes toLower() and replaces the low-signal acknowledgement filters with simple case variants (thanks/Thanks/THANKS, etc.).